### PR TITLE
Quick remove the cut and paste error

### DIFF
--- a/Community/powerplatformlicensingforcitizendeveloper.md
+++ b/Community/powerplatformlicensingforcitizendeveloper.md
@@ -79,8 +79,6 @@ The following set of points discuss the license differences:
   - User with a license can run unlimited number of apps
   - Also known simply as the &quot;Per User Plan&quot;
   - Standard, Premium and Custom Connectors included
-  - User with a license runs up to two specific apps
-  - Sometimes referred to as the &quot;Per App&quot; Plan
   - Standard and Premium Connectors included
   - Unlimited Access to the (single) tenant portal
   - Access to on premises resources via a data gateway


### PR DESCRIPTION
Issue  cited by visitor "Akaskela" (thank you!) ... it was a cut and paste error that got undone in one of the updates.
#### Category
- [x] Content fix
- [ ] New article

#### Related issues:
- mentioned in  #141 

#### What's in this Pull Request?
While working on 141, comment came it citing the cut and paste error which can be fixed immediately.  Remove the errant lines 

#### Guidance

Fix as noted thanks 