### PR TITLE
Fix incorrect default list versioning information

### DIFF
--- a/Community/versioning-basics-best-practices.md
+++ b/Community/versioning-basics-best-practices.md
@@ -60,7 +60,7 @@ Historically, versioning is not enabled by default at the creation of a list or 
 
 |What| Online| On-Premises|
 |:------| :-----| :-----|
-|Lists| Not enabled at creation| Not enabled at creation |
+|Lists| Enabled at creation (and set to 50 versions)| Not enabled at creation |
 |Libraries|Enabled at creation (and set to 500 versions)|Not enabled at creation|
 
 > [!Note]


### PR DESCRIPTION
#### Category

- [x] Content fix
- [ ] New article

#### Related issues

#423 

#### Contents of the Pull Request

**Issue**

The documentation states that versioning is not enabled by default when a list is created in SharePoint Online. However, versioning is enabled on creation of a list in SharePoint Online and is set to 50 versions by default.

**Fix**

The table has been corrected and states that versioning is enabled on creation, along with the default number of versions.