### PR TITLE
"How do they manage them" section updated

### DIFF
--- a/Community/all-about-groups.md
+++ b/Community/all-about-groups.md
@@ -56,7 +56,7 @@ By default, any user in a tenant can create a Microsoft 365 Group by creating a 
 
 ### How do they manage them?
 
-Group Owners can manage Group membership in any of the Group supported applications. For instance, they can add a member to a Group from the SharePoint site, Outlook, Outlook Online, the Teams app, and so on. Changes to the Group made in any app are reflected in all of the apps that Group supports. The management experience is not the same between apps, so an Owner may have to go to a specific app for a specific task. For instance, to change a Group's Privacy policy you have to use Outlook or Outlook online. That setting can't be changed in SharePoint. Users that have the appropriate administrative roles can also create Microsoft 365 Groups from the Azure Portal or PowerShell. They can also manage Group membership and settings from those same interfaces.
+Group Owners can manage Group membership in any of the Group supported applications. For instance, they can add a member to a Group from the SharePoint site, Outlook, Outlook Online, the Teams app, and so on. Changes to the Group made in any app are reflected in all of the apps that Group supports. The management experience is not the same between apps, so an Owner may have to go to a specific app for a specific task. For instance, to add guest users to office 365 group(both private and public) use Outlook or Outlook online. This setting is not present in SharePoint. Users that have the appropriate administrative roles can also create Microsoft 365 Groups from the Azure Portal or PowerShell. They can also manage Group membership and settings from those same interfaces.
 
 ### How are they used?
 


### PR DESCRIPTION
SharePoint Online UI allows to update the group privacy bit this statement was incorrect "For instance, to change a Group's Privacy policy you have to use Outlook or Outlook online. That setting can't be changed in SharePoint." 

It is updated as below with other example

For instance, to add guest users to office 365 group(both private and public) use Outlook or Outlook online. This setting is not present in SharePoint.

# Please use this template to ensure easier processing of your pull request

#### Category

- [ ] Content fix
- [ ] New article
- [x] Example checked item (*delete this line*)

> For the above list, an empty checkbox is [ ] as in <kbd>[</kbd><kbd>SPACE</kbd><kbd>]</kbd>. A checked checkbox is [x] with no space between the brackets. Use the `PREVIEW` tab at the top right to preview the rendering before submitting your issue.
>
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### Related issues

- fixes #issuenumber
- partially #issuenumber
- mentioned in #issuenumber

> If this fixes (should close) or references an issue, please add the issue number here. When you type the hashtag symbol (#), a list of potential issues will pop up from which you can choose. This helps those maintaining the issue list as it will (1) link the PR to the issue & (2) automatically close the issue when this PR is merged in.
>
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### Contents of the Pull Request

> Please describe the changes in this PR. Try to give enough details so the person reviewing it to merge it can make a good decision about your content.
>
> _(DELETE THIS PARAGRAPH AFTER READING)_

#### Guidance

> *Please update this PR information accordingly. We'll use this as part of our release notes in monthly communications.*
>
> *Please target your PR to `master` branch. Released documents are in `live` branch.*
>
> _(DELETE THIS PARAGRAPH AFTER READING)_