### PR TITLE
Replace the reference to Classic Stream

### DIFF
--- a/Community/library-scenarios.md
+++ b/Community/library-scenarios.md
@@ -88,7 +88,7 @@ Example image shown below:
 
 ![Image of a multimedia document library used as an organization asset library.](media/library-scenarios/multimedia-scenario-02.png)
 
->Video files intended for streaming use should be hosted in [Microsoft Stream](/stream/overview).
+>For video files intended for streaming check this [Overview of how to feature videos in Microsoft 365 with pages, sites, & portals](https://docs.microsoft.com/en-us/stream/streamnew/portals-overview).
 
 ---
 

--- a/Community/library-scenarios.md
+++ b/Community/library-scenarios.md
@@ -88,7 +88,7 @@ Example image shown below:
 
 ![Image of a multimedia document library used as an organization asset library.](media/library-scenarios/multimedia-scenario-02.png)
 
->For video files intended for streaming check this [Overview of how to feature videos in Microsoft 365 with pages, sites, & portals](https://docs.microsoft.com/en-us/stream/streamnew/portals-overview).
+>For video files intended for streaming check this [Overview of how to feature videos in Microsoft 365 with pages, sites, & portals](https://docs.microsoft.com/stream/streamnew/portals-overview).
 
 ---
 


### PR DESCRIPTION
Replaced the reference to Classic Stream with a link to an Overview of how to feature videos in Microsoft 365 with pages, sites, & portals

# Please use this template to ensure easier processing of your pull request

#### Category

- [x] Content fix
- [ ] New article

#### Related issues

- fixes #issuenumber
- partially #issuenumber
- mentioned in #issuenumber

#### Contents of the Pull Request

Replaced the last paragraph about video content. Instead of reference to Classic Stream I put a link to an Overview of how to feature videos in Microsoft 365 with pages, sites, & portals at https://docs.microsoft.com/en-us/stream/streamnew/portals-overview

#### Guidance
