### PR TITLE
Updated note on versioning impact on SharePoint storage usage

### DIFF
--- a/Community/versioning-basics-best-practices.md
+++ b/Community/versioning-basics-best-practices.md
@@ -75,7 +75,7 @@ Libraries can have both Major versions, which are represented with whole numbers
 Lists usually only have Major versions.
 
 > [!NOTE]
-> All versions count against your SharePoint storage usage, as do files in the recycle bins and files preserved due to retention policies.
+> All versions count against your SharePoint storage usage, as do files in the recycle bins and files preserved due to retention policies. In calculating the SharePoint storage usage, the full file size of each version counts towards the total usage. For example, if only metadata changes were made to a 10 MB file with no change to its file size, the total storage usage will be 10 MB (original version) + 10 MB (updated version) = 20 MB.
 
 ## Best Practices and Versioning Trivia
 


### PR DESCRIPTION
Added text in existing Note describing versioning impact to SharePoint storage usage.

# Please use this template to ensure easier processing of your pull request

#### Category

- [x] Content fix
- [ ] New article

#### Related issues

- fixes #665 
- partially #issuenumber
- mentioned in #issuenumber

#### Contents of the Pull Request

> Added text in existing Note describing versioning impact to SharePoint storage usage.  This detail has been confirmed by Microsoft support teams, but I have not seen it clarified to detail the true impact of each version being counted at full size of the file.