### PR TITLE
[BULK UPDATE] DocuTune - Rebranding links

### DIFF
--- a/Community/query-string-url-tricks-sharepoint-m365.md
+++ b/Community/query-string-url-tricks-sharepoint-m365.md
@@ -28,33 +28,33 @@ This article will cover some powerful parameters that you can stick on the tail 
 
 You know this URL brings you to a website:
 
-`https://docs.microsoft.com`
+`https://learn.microsoft.com`
 
 And this one brings you to a specific _section_ of that same website:
 
-`https://docs.microsoft.com/search/`
+`https://learn.microsoft.com/search/`
 
 What about this URL?
 
-`https://docs.microsoft.com/search/?terms=community%20content`
+`https://learn.microsoft.com/search/?terms=community%20content`
 
 It has a **?** at the end with a key (_terms_) and a value (_community content_). This is a **query string**. Based on the key and value in it, we can infer that it might affect or influence the page to show different content.
 
 In this example, we can change the value in our address bar (and hit _return_) and the page content may be different. Example:
 
-`https://docs.microsoft.com/search/?terms=large%lists`
+`https://learn.microsoft.com/search/?terms=large%lists`
 
 ### Multiple filters
 
 Here's an example of multiple filtering with two keys (_products_ and _languages_) with their corresponding values (_m365_ and _javascript_):
 
-`https://docs.microsoft.com/samples/browse`
+`https://learn.microsoft.com/samples/browse`
 
-`https://docs.microsoft.com/samples/browse?products=m365&languages=javascript`
+`https://learn.microsoft.com/samples/browse?products=m365&languages=javascript`
 
 And here's that same page loads different content with different values (_ms-graph_ and _html_)
 
-`https://docs.microsoft.com/samples/browse/?products=ms-graph&languages=html`
+`https://learn.microsoft.com/samples/browse/?products=ms-graph&languages=html`
 
 How does this mental modal of _URL-as-page-transformer_ work in Microsoft 365? Keep reading!
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome to the Microsoft 365 Community Docs
 
-* This repo backs the [Microsoft 365 Community Docs](https://docs.microsoft.com/microsoft-365/community/) content. If you have suggestion or corrections, read on...
+* This repo backs the [Microsoft 365 Community Docs](https://learn.microsoft.com/microsoft-365/community/) content. If you have suggestion or corrections, read on...
 * If you just landed here, and you have no idea what GitHub is, please go to [Getting Started](https://github.com/MicrosoftDocs/microsoft-365-community/wiki/Getting-Started). If you'd like to learn even more about how to use Github in this context, visit the [Sharing Is Caring Initiative](https://pnp.github.io/sharing-is-caring/).
 * If you have been here before and would like instructions on how to add content, please go to [Adding Content](https://github.com/MicrosoftDocs/microsoft-365-community/wiki/Adding-Content).
 * Curious what types of articles we have here? Check out the [Community Table of Contents](Community/TOC.md) in the Community section.
@@ -11,7 +11,7 @@ This repository is here for YOU. The goal is to build an open source set of cont
 
 There are lots of other resources for developers, so that isn't our target audience. We may include some code samples or snippets of code in the context of getting something done, but for the most part, any code in this repository will exist to help facilitate conversations between the folks listed above and the developers with whom they work.
 
-This content is available in the [Microsoft 365 Community Docs](https://docs.microsoft.com/microsoft-365/community/). Contribute and be a part of history!
+This content is available in the [Microsoft 365 Community Docs](https://learn.microsoft.com/microsoft-365/community/). Contribute and be a part of history!
 
 ## Questions & Help
 
@@ -26,7 +26,7 @@ If you are looking for documentation about something which you feel fits this mo
 To keep track of Microsoft 365 Community Docs updates, please follow us:
 
 * Twitter: [@M365CommDocs](https://twitter.com/M365CommDocs) and the [#M365CommunityDocs](https://twitter.com/hashtag/M365CommunityDocs) hashtag
-* [Microsoft 365 Community Docs](https://docs.microsoft.com/microsoft-365/community/)
+* [Microsoft 365 Community Docs](https://learn.microsoft.com/microsoft-365/community/)
 
 ## Have Fun
 


### PR DESCRIPTION
**Global effort for the Microsoft Learn platform rebrand**

The Microsoft team is applying changes to content for the Microsoft Learn platform rebrand. Changes include modifications to current Microsoft Learn and Microsoft Docs terminology as well as associated domain name and content URL path changes.

**DO NOT MERGE THIS PULL REQUEST WHILE IN DRAFT STATUS!** Some of the changes to links and other content are not valid until after go-live.

Please review this draft PR and provide any necessary comments as soon as possible. Because these fixes are tightly scoped, we have approval to automatically merge these changes to the default branch for publication.

This PR was generated via DocuTune. It includes only targeted fixes and minor formatting adjustments.

CorrelationId: d8c4c3ac-d49a-4c95-9ddc-9822ca297907
InitiativeId: docutune-rebranding-2022-09
PointOfContact: Alex Buck
